### PR TITLE
TravisCI / AppVeyor による CI の対応

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,102 @@
+version: "0.2.5 build #{build}"
+shallow_clone: true
+
+environment:
+  SOLUTION: arib_std_b25.sln
+  BUILDENV: MSBUILD
+
+  MSYS2_DIR: msys64
+
+  CYGWIN_MIRROR: http://cygwin.mirror.constant.com
+  CYGWIN_PACKAGES: mpfr,mpc,gcc-core,gcc=g++,make,cmake
+
+  matrix:
+    # Latest version of VisualStudio
+    - GENERATOR: "Visual Studio 15 2017"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - GENERATOR: "Visual Studio 15 2017 Win64"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    # Windows Server 2008R2 or Windows 7 or above
+    - GENERATOR: "Visual Studio 14 2015"
+    - GENERATOR: "Visual Studio 14 2015 Win64"
+    - GENERATOR: "Visual Studio 12 2013"
+    - GENERATOR: "Visual Studio 12 2013 Win64"
+    - GENERATOR: "Visual Studio 11 2012"
+    - GENERATOR: "Visual Studio 11 2012 Win64"
+
+    # WindowsXP or above (C99 is not yet supported)
+    - GENERATOR: "Visual Studio 10 2010"
+    - GENERATOR: "Visual Studio 10 2010 Win64"
+    - GENERATOR: "Visual Studio 9 2008"
+
+    # MSYS2
+    - GENERATOR: "MSYS Makefiles"
+      BUILDENV: MSYS2
+      MSYS2_ARCH: i686
+      MSYSTEM: MINGW32
+
+    - GENERATOR: "MSYS Makefiles"
+      BUILDENV: MSYS2
+      MSYS2_ARCH: x86_64
+      MSYSTEM: MINGW64
+
+    # Cygwin
+    - GENERATOR: "Unix Makefiles"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      BUILDENV: CYGWIN
+      CYGWIN_DIR: cygwin
+      CYGWIN_ARCH: x86
+
+    - GENERATOR: "Unix Makefiles"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      BUILDENV: CYGWIN
+      CYGWIN_DIR: cygwin64
+      CYGWIN_ARCH: x86_64
+
+install:
+  - if "%BUILDENV%" == "MSYS2"
+      set MSYS2_ROOT=%HOMEDRIVE%\%MSYS2_DIR%
+  - if "%BUILDENV%" == "CYGWIN"
+      set CYGWIN_ROOT=%HOMEDRIVE%\%CYGWIN_DIR%
+
+  - if "%BUILDENV%" == "CYGWIN" (
+      appveyor
+        DownloadFile "https://cygwin.com/setup-%CYGWIN_ARCH%.exe"
+        -FileName "%CYGWIN_ROOT%/setup-%CYGWIN_ARCH%.exe" &&
+      "%CYGWIN_ROOT%/setup-%CYGWIN_ARCH%.exe"
+        -qnNdOW
+        --root "%CYGWIN_ROOT%"
+        --site "%CYGWIN_MIRROR%"
+        --local-package-dir "%CYGWIN_ROOT%/var/cache/setup"
+        --packages "%CYGWIN_PACKAGES%"
+    )
+
+before_build:
+  - mkdir build
+
+  - if "%BUILDENV%" == "MSBUILD" (
+      cd build &&
+      cmake -G "%GENERATOR%" ..
+    )
+
+  - if "%BUILDENV%" == "MSYS2" (
+      mklink /D "%MSYS2_ROOT%/home/%USERNAME%/work" "%APPVEYOR_BUILD_FOLDER%" &&
+      "%MSYS2_ROOT%/usr/bin/bash" --login -c 'cd work/build; cmake -G "%GENERATOR%" ..'
+    )
+
+  - if "%BUILDENV%" == "CYGWIN" (
+      mklink /D "%CYGWIN_ROOT%/home/%USERNAME%/work" "%APPVEYOR_BUILD_FOLDER%" &&
+      "%CYGWIN_ROOT%/bin/bash" --login -c 'cd ~/work/build; cmake -G "%GENERATOR%" ..'
+    )
+
+
+build_script:
+  - if "%BUILDENV%" == "MSBUILD"
+      msbuild "%SOLUTION%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+  - if "%BUILDENV%" == "MSYS2"
+      "%MSYS2_ROOT%/usr/bin/bash" --login -c 'cd ~/work/build; make'
+
+  - if "%BUILDENV%" == "CYGWIN"
+      "%CYGWIN_ROOT%/bin/bash" --login -c 'cd ~/work/build; make'

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_life = lf
+charset = utf-8
+indent_style = tab
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+sudo: false
+language: c
+
+matrix:
+  include:
+    # Linux with GNU C Compiler
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
+          packages:
+            - gcc
+            - cmake
+            - cmake-data
+            - libpcsclite-dev
+  
+    # Linux with LLVM C Compiler
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
+          packages:
+            - clang
+            - cmake
+            - cmake-data
+            - libpcsclite-dev
+
+    # MacOS X 10.10 (Yosemite)
+    - os: osx
+      osx_image: xcode6.4
+      compiler: clang
+
+    # MacOS X 10.11 (El Captain)
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+
+    # macOS 10.11 (Sierra)
+    - os: osx 
+      osx_image: xcode8
+      compiler: clang
+
+script:
+  - install -d build
+  - cd build
+  - cmake ..
+  - make VERBOSE=1
+  - ./b25 2>&1 | grep "ARIB STD-B25"


### PR DESCRIPTION
### 主な変更点
下記の通り変更を行いましたので、お手数をおかけしますがよろしければマージをお願いします。
また、お手すきの際にでも Travi CI / AppVeyor の設定をして頂けると幸いです。

* Travis CI への対応
* AppVeyor への対応

先日プルリクを出させていただいたMacOS X への移植 (#8) 等により対応するビルド環境が増加したため、ソースコードの変更が他の環境でのビルドに与える影響を検証する手間が増大してしまいましたので、今後の開発の助けになればと思い自動化させていただきました。

Visual Studio では 2012 から C99 のほとんどが実装されましたが、
それ以前の VisualStudio では `<stdint.h>` が存在しません。

また、いくつかの環境特有の問題で互換性のために記述されたマクロ等が多数存在しています。
他の開発者が全ての OS のビルド環境を用意して検証するのは現実的ではないので、
こちらを活用していただければと思います。

### CI 実行内容
 * Travis CI (for UNIX / MacOS X)
   - Linux GNU C Compiler
   - Linux LLVM Clang Compiler
   - MacOS X Apple Clang Compiler Xcode 6.4 (MacOS X 10.10 Yosemite)
   - MacOS X Apple Clang Compiler Xcode 7.3 (MacOS X 10.11 El Captain)
   - MacOS X Apple Clang Compiler Xcode 10.11 (macOS Sierra)


 * AppVeyor (for Windows)
   - Windows Visual Studio 15 2017
   - Windows Visual Studio 15 2017 Win64
   - Windows Visual Studio 14 2015
   - Windows Visual Studio 14 2015 Win64
   - Windows Visual Studio 12 2013
   - Windows Visual Studio 12 2013 Win64
   - Windows Visual Studio 11 2012 †[1]
   - Windows Visual Studio 11 2012 Win64 †[1]
   - Windows Visual Studio 10 2010
   - Windows Visual Studio 10 2010 Win64
   - Windows Visual Studio 9 2008 †[2]
   - Windows MinGW32 on MSYS2
   - Windows MinGW64 on MSYS2
   - Windows Cygwin32
   - Windows Cygwin64

†[1]: C99 標準にほぼ対応した最初のバージョン Windows7 以降の開発に対応  
†[2]: Visual Studio 9 では、x86_64 アーキテクチャはインストール時に指定しないと使えません。AppVeyor では対応していないみたいなので x86 のみの対応にとどまっています。

全ての Visual Studio でビルドするのは冗長な気もしていますが、念のために Visual Studio 2008 以降全てを対象にしました。実際 libarib25 のコードベースで互換性が問題になるのは C99 のうち `<stdint.h>` の有無くらいであると思うので、Visual Studio 2012 未満と以上の境界以外はあまりテストする意味はないのかもしれません。現在、AppVeyor の CI 実行に 10 分程度かかっているので不要なテストは削除あるいは、コメントアウトしても良いかと思いますが今後 CI が頻繁に走るほど多くの変更が入るとも思えないので現状のままとしました。

余談ですが、Visual Studio 13 は忌み数のため欠番となっているようです。

### 参考
  * https://docs.travis-ci.com/user/multi-os/ Travis CI Multiple Operating System
  * https://www.appveyor.com/docs/build-environment/ AppVeyor Build Environment
  * https://www.microsoft.com/ja-jp/dev/support/tools.aspx 開発ツール対応 OS 一覧