### PR TITLE
Windows において UNICODE 対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,10 @@ if (UNIX OR MSYS)
 	set(WITH_PCSC_LIBRARY "" CACHE STRING "library name for PC/SC")
 endif()
 
+if(WIN32)
+	option(USE_UNICODE "enable unicode support" ON)
+endif()
+
 set(ARIB25_LIB_NAME "arib25")
 set(ARIB25_CMD_NAME "b25")
 
@@ -47,6 +51,10 @@ if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)")
 	else(MINGW)
 		set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--enable-stdcall-fixup -static-libgcc")
 	endif()
+
+	if(MINGW AND USE_UNICODE)
+		set(CMAKE_C_FLAGS "-municode ${CMAKE_C_FLAGS}")
+	endif()
 elseif(CMAKE_C_COMPILER_ID MATCHES "(MSVC)")
 	add_definitions("-D_CRT_SECURE_NO_WARNINGS")
 	set(CMAKE_STATIC_LIBRARY_PREFIX lib)
@@ -56,6 +64,10 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	add_definitions("-DDEBUG")
+endif()
+
+if(USE_UNICODE)
+	add_definitions("-DUNICODE" "-D_UNICODE")
 endif()
 
 add_definitions("-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64")

--- a/src/b_cas_card.c
+++ b/src/b_cas_card.c
@@ -6,10 +6,14 @@
 
 #include <math.h>
 
-#if defined(WIN32) || defined(__CYGWIN__)
+#if defined(WIN32)
 #  include <windows.h>
+#  include <tchar.h>
 #else
-#  include <wintypes.h>
+#  if !defined(__CYGWIN__)
+#    include <wintypes.h>
+#  endif
+#  define _tcslen strlen
 #endif
 #include <winscard.h>
 
@@ -22,7 +26,7 @@ typedef struct {
 	SCARDHANDLE        card;
 
 	uint8_t           *pool;
-	char              *reader;
+	LPTSTR             reader;
 
 	uint8_t           *sbuf;
 	uint8_t           *rbuf;
@@ -111,7 +115,7 @@ static B_CAS_CARD_PRIVATE_DATA *private_data(void *bcas);
 static void teardown(B_CAS_CARD_PRIVATE_DATA *prv);
 static int change_id_max(B_CAS_CARD_PRIVATE_DATA *prv, int max);
 static int change_pwc_max(B_CAS_CARD_PRIVATE_DATA *prv, int max);
-static int connect_card(B_CAS_CARD_PRIVATE_DATA *prv, const char *reader_name);
+static int connect_card(B_CAS_CARD_PRIVATE_DATA *prv, LPCTSTR reader_name);
 static void extract_power_on_ctrl_response(B_CAS_PWR_ON_CTRL *dst, uint8_t *src);
 static void extract_mjd(int *yy, int *mm, int *dd, int mjd);
 static int setup_ecm_receive_command(uint8_t *dst, uint8_t *src, int len);
@@ -168,7 +172,7 @@ static int init_b_cas_card(void *bcas)
 		return B_CAS_CARD_ERROR_NO_ENOUGH_MEMORY;
 	}
 
-	prv->reader = (char *)(prv->pool);
+	prv->reader = (LPTSTR)(prv->pool);
 	prv->sbuf = prv->pool + len;
 	prv->rbuf = prv->sbuf + B_CAS_BUFFER_MAX;
 	prv->id.data = (int64_t *)(prv->rbuf + B_CAS_BUFFER_MAX);
@@ -185,7 +189,7 @@ static int init_b_cas_card(void *bcas)
 		if(connect_card(prv, prv->reader)){
 			break;
 		}
-		prv->reader += (strlen(prv->reader) + 1);
+		prv->reader += (_tcslen(prv->reader) + 1);
 	}
 
 	if(prv->card == 0){
@@ -517,7 +521,7 @@ static int change_id_max(B_CAS_CARD_PRIVATE_DATA *prv, int max)
 	old_reader = (uint8_t *)(prv->reader);
 	old_pwctrl = (uint8_t *)(prv->pwc.data);
 
-	prv->reader = (char *)p;
+	prv->reader = (LPTSTR)p;
 	prv->sbuf = prv->pool + reader_size;
 	prv->rbuf = prv->sbuf + B_CAS_BUFFER_MAX;
 	prv->id.data = (int64_t *)(prv->rbuf + B_CAS_BUFFER_MAX);
@@ -558,7 +562,7 @@ static int change_pwc_max(B_CAS_CARD_PRIVATE_DATA *prv, int max)
 	old_reader = (uint8_t *)(prv->reader);
 	old_cardid = (uint8_t *)(prv->id.data);
 
-	prv->reader = (char *)p;
+	prv->reader = (LPTSTR)p;
 	prv->sbuf = prv->pool + reader_size;
 	prv->rbuf = prv->sbuf + B_CAS_BUFFER_MAX;
 	prv->id.data = (int64_t *)(prv->rbuf + B_CAS_BUFFER_MAX);
@@ -574,7 +578,7 @@ static int change_pwc_max(B_CAS_CARD_PRIVATE_DATA *prv, int max)
 	return 0;
 }
 
-static int connect_card(B_CAS_CARD_PRIVATE_DATA *prv, const char *reader_name)
+static int connect_card(B_CAS_CARD_PRIVATE_DATA *prv, LPCTSTR reader_name)
 {
 	int m,n;
 	

--- a/src/td.c
+++ b/src/td.c
@@ -11,8 +11,15 @@
 	#include <io.h>
 	#include <windows.h>
 	#include <crtdbg.h>
+	#include <tchar.h>
 #else
 	#define __STDC_FORMAT_MACROS
+	#define TCHAR char
+	#define _T(X) X
+	#define _ftprintf fprintf
+	#define _ttoi atoi
+	#define _tmain main
+	#define _topen _open
 	#include <inttypes.h>
 	#include <unistd.h>
 	#include <sys/time.h>
@@ -30,11 +37,11 @@ typedef struct {
 } OPTION;
 
 static void show_usage();
-static int parse_arg(OPTION *dst, int argc, char **argv);
-static void test_arib_std_b25(const char *src, const char *dst, OPTION *opt);
+static int parse_arg(OPTION *dst, int argc, TCHAR **argv);
+static void test_arib_std_b25(const TCHAR *src, const TCHAR *dst, OPTION *opt);
 static void show_bcas_power_on_control_info(B_CAS_CARD *bcas);
 
-int main(int argc, char **argv)
+int _tmain(int argc, TCHAR **argv)
 {
 	int n;
 	OPTION opt;
@@ -68,27 +75,27 @@ int main(int argc, char **argv)
 
 static void show_usage()
 {
-	fprintf(stderr, "b25 - ARIB STD-B25 test program version %s (%s)\n", ARIB25_VERSION_STRING, BUILD_GIT_REVISION);
-	fprintf(stderr, "  built with %s %s on %s\n", BUILD_CC_NAME, BUILD_CC_VERSION, BUILD_OS_NAME);
-	fprintf(stderr, "usage: b25 [options] src.m2t dst.m2t [more pair ..]\n");
-	fprintf(stderr, "options:\n");
-	fprintf(stderr, "  -r round (integer, default=4)\n");
-	fprintf(stderr, "  -s strip\n");
-	fprintf(stderr, "     0: keep null(padding) stream (default)\n");
-	fprintf(stderr, "     1: strip null stream\n");
-	fprintf(stderr, "  -m EMM\n");
-	fprintf(stderr, "     0: ignore EMM (default)\n");
-	fprintf(stderr, "     1: send EMM to B-CAS card\n");
-	fprintf(stderr, "  -p power_on_control_info\n");
-	fprintf(stderr, "     0: do nothing additionaly\n");
-	fprintf(stderr, "     1: show B-CAS EMM receiving request (default)\n");
-	fprintf(stderr, "  -v verbose\n");
-	fprintf(stderr, "     0: silent\n");
-	fprintf(stderr, "     1: show processing status (default)\n");
-	fprintf(stderr, "\n");
+	_ftprintf(stderr, _T("b25 - ARIB STD-B25 test program version %s (%s)\n"), _T(ARIB25_VERSION_STRING), _T(BUILD_GIT_REVISION));
+	_ftprintf(stderr, _T("  built with %s %s on %s\n"), _T(BUILD_CC_NAME), _T(BUILD_CC_VERSION), _T(BUILD_OS_NAME));
+	_ftprintf(stderr, _T("usage: b25 [options] src.m2t dst.m2t [more pair ..]\n"));
+	_ftprintf(stderr, _T("options:\n"));
+	_ftprintf(stderr, _T("  -r round (integer, default=4)\n"));
+	_ftprintf(stderr, _T("  -s strip\n"));
+	_ftprintf(stderr, _T("     0: keep null(padding) stream (default)\n"));
+	_ftprintf(stderr, _T("     1: strip null stream\n"));
+	_ftprintf(stderr, _T("  -m EMM\n"));
+	_ftprintf(stderr, _T("     0: ignore EMM (default)\n"));
+	_ftprintf(stderr, _T("     1: send EMM to B-CAS card\n"));
+	_ftprintf(stderr, _T("  -p power_on_control_info\n"));
+	_ftprintf(stderr, _T("     0: do nothing additionaly\n"));
+	_ftprintf(stderr, _T("     1: show B-CAS EMM receiving request (default)\n"));
+	_ftprintf(stderr, _T("  -v verbose\n"));
+	_ftprintf(stderr, _T("     0: silent\n"));
+	_ftprintf(stderr, _T("     1: show processing status (default)\n"));
+	_ftprintf(stderr, _T("\n"));
 }
 
-static int parse_arg(OPTION *dst, int argc, char **argv)
+static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 {
 	int i;
 	
@@ -105,46 +112,46 @@ static int parse_arg(OPTION *dst, int argc, char **argv)
 		switch(argv[i][1]){
 		case 'm':
 			if(argv[i][2]){
-				dst->emm = atoi(argv[i]+2);
+				dst->emm = _ttoi(argv[i]+2);
 			}else{
-				dst->emm = atoi(argv[i+1]);
+				dst->emm = _ttoi(argv[i+1]);
 				i += 1;
 			}
 			break;
 		case 'p':
 			if(argv[i][2]){
-				dst->power_ctrl = atoi(argv[i]+2);
+				dst->power_ctrl = _ttoi(argv[i]+2);
 			}else{
-				dst->power_ctrl = atoi(argv[i+1]);
+				dst->power_ctrl = _ttoi(argv[i+1]);
 				i += 1;
 			}
 			break;
 		case 'r':
 			if(argv[i][2]){
-				dst->round = atoi(argv[i]+2);
+				dst->round = _ttoi(argv[i]+2);
 			}else{
-				dst->round = atoi(argv[i+1]);
+				dst->round = _ttoi(argv[i+1]);
 				i += 1;
 			}
 			break;
 		case 's':
 			if(argv[i][2]){
-				dst->strip = atoi(argv[i]+2);
+				dst->strip = _ttoi(argv[i]+2);
 			}else{
-				dst->strip = atoi(argv[i+1]);
+				dst->strip = _ttoi(argv[i+1]);
 				i += 1;
 			}
 			break;
 		case 'v':
 			if(argv[i][2]){
-				dst->verbose = atoi(argv[i]+2);
+				dst->verbose = _ttoi(argv[i]+2);
 			}else{
-				dst->verbose = atoi(argv[i+1]);
+				dst->verbose = _ttoi(argv[i+1]);
 				i += 1;
 			}
 			break;
 		default:
-			fprintf(stderr, "error - unknown option '-%c'\n", argv[i][1]);
+			_ftprintf(stderr, _T("error - unknown option '-%c'\n"), argv[i][1]);
 			return argc;
 		}
 	}
@@ -152,7 +159,7 @@ static int parse_arg(OPTION *dst, int argc, char **argv)
 	return i;
 }
 
-static void test_arib_std_b25(const char *src, const char *dst, OPTION *opt)
+static void test_arib_std_b25(const TCHAR *src, const TCHAR *dst, OPTION *opt)
 {
 	int code,i,n,m;
 	int sfd,dfd;
@@ -182,9 +189,9 @@ static void test_arib_std_b25(const char *src, const char *dst, OPTION *opt)
 	b25 = NULL;
 	bcas = NULL;
 
-	sfd = _open(src, _O_BINARY|_O_RDONLY|_O_SEQUENTIAL);
+	sfd = _topen(src, _O_BINARY|_O_RDONLY|_O_SEQUENTIAL);
 	if(sfd < 0){
-		fprintf(stderr, "error - failed on _open(%s) [src]\n", src);
+		_ftprintf(stderr, _T("error - failed on _open(%s) [src]\n"), src);
 		goto LAST;
 	}
 	
@@ -194,49 +201,49 @@ static void test_arib_std_b25(const char *src, const char *dst, OPTION *opt)
 
 	b25 = create_arib_std_b25();
 	if(b25 == NULL){
-		fprintf(stderr, "error - failed on create_arib_std_b25()\n");
+		_ftprintf(stderr, _T("error - failed on create_arib_std_b25()\n"));
 		goto LAST;
 	}
 
 	code = b25->set_multi2_round(b25, opt->round);
 	if(code < 0){
-		fprintf(stderr, "error - failed on ARIB_STD_B25::set_multi2_round() : code=%d\n", code);
+		_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::set_multi2_round() : code=%d\n"), code);
 		goto LAST;
 	}
 
 	code = b25->set_strip(b25, opt->strip);
 	if(code < 0){
-		fprintf(stderr, "error - failed on ARIB_STD_B25::set_strip() : code=%d\n", code);
+		_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::set_strip() : code=%d\n"), code);
 		goto LAST;
 	}
 
 	code = b25->set_emm_proc(b25, opt->emm);
 	if(code < 0){
-		fprintf(stderr, "error - failed on ARIB_STD_B25::set_emm_proc() : code=%d\n", code);
+		_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::set_emm_proc() : code=%d\n"), code);
 		goto LAST;
 	}
 
 	bcas = create_b_cas_card();
 	if(bcas == NULL){
-		fprintf(stderr, "error - failed on create_b_cas_card()\n");
+		_ftprintf(stderr, _T("error - failed on create_b_cas_card()\n"));
 		goto LAST;
 	}
 
 	code = bcas->init(bcas);
 	if(code < 0){
-		fprintf(stderr, "error - failed on B_CAS_CARD::init() : code=%d\n", code);
+		_ftprintf(stderr, _T("error - failed on B_CAS_CARD::init() : code=%d\n"), code);
 		goto LAST;
 	}
 
 	code = b25->set_b_cas_card(b25, bcas);
 	if(code < 0){
-		fprintf(stderr, "error - failed on ARIB_STD_B25::set_b_cas_card() : code=%d\n", code);
+		_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::set_b_cas_card() : code=%d\n"), code);
 		goto LAST;
 	}
 
-	dfd = _open(dst, _O_BINARY|_O_WRONLY|_O_SEQUENTIAL|_O_CREAT|_O_TRUNC, _S_IREAD|_S_IWRITE);
+	dfd = _topen(dst, _O_BINARY|_O_WRONLY|_O_SEQUENTIAL|_O_CREAT|_O_TRUNC, _S_IREAD|_S_IWRITE);
 	if(dfd < 0){
-		fprintf(stderr, "error - failed on _open(%s) [dst]\n", dst);
+		_ftprintf(stderr, _T("error - failed on _open(%s) [dst]\n"), dst);
 		goto LAST;
 	}
 
@@ -252,20 +259,20 @@ static void test_arib_std_b25(const char *src, const char *dst, OPTION *opt)
 
 		code = b25->put(b25, &sbuf);
 		if(code < 0){
-			fprintf(stderr, "error - failed on ARIB_STD_B25::put() : code=%d\n", code);
+			_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::put() : code=%d\n"), code);
 			goto LAST;
 		}
 
 		code = b25->get(b25, &dbuf);
 		if(code < 0){
-			fprintf(stderr, "error - failed on ARIB_STD_B25::get() : code=%d\n", code);
+			_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::get() : code=%d\n"), code);
 			goto LAST;
 		}
 
 		if(dbuf.size > 0){
 			n = _write(dfd, dbuf.data, dbuf.size);
 			if(n != dbuf.size){
-				fprintf(stderr, "error failed on _write(%d)\n", dbuf.size);
+				_ftprintf(stderr, _T("error failed on _write(%d)\n"), dbuf.size);
 				goto LAST;
 			}
 		}
@@ -291,26 +298,26 @@ static void test_arib_std_b25(const char *src, const char *dst, OPTION *opt)
 				mbps /= millisec;
 			}
 #endif
-			fprintf(stderr, "\rprocessing: %2d.%02d%% [%6.2f MB/sec]", m/100, m%100, mbps);
+			_ftprintf(stderr, _T("\rprocessing: %2d.%02d%% [%6.2f MB/sec]"), m/100, m%100, mbps);
 		}
 	}
 
 	code = b25->flush(b25);
 	if(code < 0){
-		fprintf(stderr, "error - failed on ARIB_STD_B25::flush() : code=%d\n", code);
+		_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::flush() : code=%d\n"), code);
 		goto LAST;
 	}
 	
 	code = b25->get(b25, &dbuf);
 	if(code < 0){
-		fprintf(stderr, "error - failed on ARIB_STD_B25::get() : code=%d\n", code);
+		_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::get() : code=%d\n"), code);
 		goto LAST;
 	}
 
 	if(dbuf.size > 0){
 		n = _write(dfd, dbuf.data, dbuf.size);
 		if(n != dbuf.size){
-			fprintf(stderr, "error - failed on _write(%d)\n", dbuf.size);
+			_ftprintf(stderr, _T("error - failed on _write(%d)\n"), dbuf.size);
 			goto LAST;
 		}
 	}
@@ -334,33 +341,33 @@ static void test_arib_std_b25(const char *src, const char *dst, OPTION *opt)
 			mbps /= millisec;
 		}
 #endif
-		fprintf(stderr, "\rprocessing: finish  [%6.2f MB/sec]\n", mbps);
+		_ftprintf(stderr, _T("\rprocessing: finish  [%6.2f MB/sec]\n"), mbps);
 		fflush(stderr);
 		fflush(stdout);
 	}
 
 	n = b25->get_program_count(b25);
 	if(n < 0){
-		fprintf(stderr, "error - failed on ARIB_STD_B25::get_program_count() : code=%d\n", code);
+		_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::get_program_count() : code=%d\n"), code);
 		goto LAST;
 	}
 	for(i=0;i<n;i++){
 		code = b25->get_program_info(b25, &pgrm, i);
 		if(code < 0){
-			fprintf(stderr, "error - failed on ARIB_STD_B25::get_program_info(%d) : code=%d\n", i, code);
+			_ftprintf(stderr, _T("error - failed on ARIB_STD_B25::get_program_info(%d) : code=%d\n"), i, code);
 			goto LAST;
 		}
 		if(pgrm.ecm_unpurchased_count > 0){
-			fprintf(stderr, "warning - unpurchased ECM is detected\n");
-			fprintf(stderr, "  channel:               %d\n", pgrm.program_number);
-			fprintf(stderr, "  unpurchased ECM count: %d\n", pgrm.ecm_unpurchased_count);
-			fprintf(stderr, "  last ECM error code:   %04x\n", pgrm.last_ecm_error_code);
+			_ftprintf(stderr, _T("warning - unpurchased ECM is detected\n"));
+			_ftprintf(stderr, _T("  channel:               %d\n"), pgrm.program_number);
+			_ftprintf(stderr, _T("  unpurchased ECM count: %d\n"), pgrm.ecm_unpurchased_count);
+			_ftprintf(stderr, _T("  last ECM error code:   %04x\n"), pgrm.last_ecm_error_code);
 			#if defined(WIN32)
-			fprintf(stderr, "  undecrypted TS packet: %I64d\n", pgrm.undecrypted_packet_count);
-			fprintf(stderr, "  total TS packet:       %I64d\n", pgrm.total_packet_count);
+			_ftprintf(stderr, _T("  undecrypted TS packet: %I64d\n"), pgrm.undecrypted_packet_count);
+			_ftprintf(stderr, _T("  total TS packet:       %I64d\n"), pgrm.total_packet_count);
 			#else
-			fprintf(stderr, "  undecrypted TS packet: %"PRId64"\n", pgrm.undecrypted_packet_count);
-			fprintf(stderr, "  total TS packet:       %"PRId64"\n", pgrm.total_packet_count);
+			_ftprintf(stderr, _T("  undecrypted TS packet: %"PRId64"\n"), pgrm.undecrypted_packet_count);
+			_ftprintf(stderr, _T("  total TS packet:       %"PRId64"\n"), pgrm.total_packet_count);
 			#endif
 		}
 	}
@@ -400,35 +407,35 @@ static void show_bcas_power_on_control_info(B_CAS_CARD *bcas)
 
 	code = bcas->get_pwr_on_ctrl(bcas, &pwc);
 	if(code < 0){
-		fprintf(stderr, "error - failed on B_CAS_CARD::get_pwr_on_ctrl() : code=%d\n", code);
+		_ftprintf(stderr, _T("error - failed on B_CAS_CARD::get_pwr_on_ctrl() : code=%d\n"), code);
 		return;
 	}
 
 	if(pwc.count == 0){
-		fprintf(stdout, "no EMM receiving request\n");
+		_ftprintf(stdout, _T("no EMM receiving request\n"));
 		return;
 	}
 
-	fprintf(stdout, "total %d EMM receiving request\n", pwc.count);
+	_ftprintf(stdout, _T("total %d EMM receiving request\n"), pwc.count);
 	for(i=0;i<pwc.count;i++){
-		fprintf(stdout, "+ [%d] : tune ", i);
+		_ftprintf(stdout, _T("+ [%d] : tune "), i);
 		switch(pwc.data[i].network_id){
 		case 4:
 			w = pwc.data[i].transport_id;
-			fprintf(stdout, "BS-%d/TS-%d ", ((w >> 4) & 0x1f), (w & 7));
+			_ftprintf(stdout, _T("BS-%d/TS-%d "), ((w >> 4) & 0x1f), (w & 7));
 			break;
 		case 6:
 		case 7:
 			w = pwc.data[i].transport_id;
-			fprintf(stdout, "ND-%d/TS-%d ", ((w >> 4) & 0x1f), (w & 7));
+			_ftprintf(stdout, _T("ND-%d/TS-%d "), ((w >> 4) & 0x1f), (w & 7));
 			break;
 		default:
-			fprintf(stdout, "unknown(b:0x%02x,n:0x%04x,t:0x%04x) ", pwc.data[i].broadcaster_group_id, pwc.data[i].network_id, pwc.data[i].transport_id);
+			_ftprintf(stdout, _T("unknown(b:0x%02x,n:0x%04x,t:0x%04x) "), pwc.data[i].broadcaster_group_id, pwc.data[i].network_id, pwc.data[i].transport_id);
 			break;
 		}
-		fprintf(stdout, "between %04d %02d/%02d ", pwc.data[i].s_yy, pwc.data[i].s_mm, pwc.data[i].s_dd);
-		fprintf(stdout, "to %04d %02d/%02d ", pwc.data[i].l_yy, pwc.data[i].l_mm, pwc.data[i].l_dd);
-		fprintf(stdout, "least %d hours\n", pwc.data[i].hold_time);
+		_ftprintf(stdout, _T("between %04d %02d/%02d "), pwc.data[i].s_yy, pwc.data[i].s_mm, pwc.data[i].s_dd);
+		_ftprintf(stdout, _T("to %04d %02d/%02d "), pwc.data[i].l_yy, pwc.data[i].l_mm, pwc.data[i].l_dd);
+		_ftprintf(stdout, _T("least %d hours\n"), pwc.data[i].hold_time);
 	}
 }
 

--- a/src/version.rc.in
+++ b/src/version.rc.in
@@ -33,7 +33,11 @@ BEGIN
 #else
       VALUE "OriginalFilename", "@ARIB25_CMD_NAME@@CMAKE_EXECUTABLE_SUFFIX@"
 #endif
+#if defined(UNICODE)
+      VALUE "ProductName",      "@ARIB25_PRODUCT@ UNICODE"
+#else
       VALUE "ProductName",      "@ARIB25_PRODUCT@"
+#endif
       VALUE "ProductVersion",   "@ARIB25_VERSION_STRING@ (" BUILD_GIT_REVISION ")"
     END
   END


### PR DESCRIPTION
Windows 版において b25.exe のコマンドライン引数に非 ASCII 文字を使用できるように UNICODE 対応しました。以前パッチを書いてから、時間が取れなくてテストできていなかったのですが問題ないようなのでプルリク出させてもらいました。

Linux 版においては一切影響はありません。
また、文字列の扱いが変わるだけで一切内部動作に変更はありません。