### PR TITLE
Fix #14 GNUInstallDirs マクロを使用して適切なデフォルトインストール先を決定

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
   MSYS2_DIR: msys64
 
   CYGWIN_MIRROR: http://cygwin.mirror.constant.com
-  CYGWIN_PACKAGES: mpfr,mpc,gcc-core,gcc=g++,make,cmake
+  CYGWIN_PACKAGES: mpfr,mpc,gcc-core,gcc-g++,make,cmake
 
   matrix:
     # Latest version of VisualStudio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE INTERNAL "limit build types"
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "default build type")
 
 set(CMAKE_INSTALL_SO_NO_EXE False)
-set(CMAKE_LEGACY_CYGWIN_WIN32 False)
 
 project(arib_std_b25 C)
 enable_language(CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.5)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE INTERNAL "limit build types" FORCE)
@@ -12,6 +12,7 @@ enable_language(CXX)
 
 include(GitRevision)
 include(GenerateExportHeader)
+include(GNUInstallDirs)
 find_package(PCSC REQUIRED)
 
 if (UNIX OR MSYS)
@@ -108,10 +109,10 @@ configure_file(src/version.rc.in version.rc @ONLY)
 if(UNIX AND NOT CYGWIN)
 	configure_file(src/libarib25.pc.in ${CMAKE_SHARED_LIBRARY_PREFIX}${ARIB25_LIB_NAME}.pc @ONLY)
 
-	install(TARGETS b25 RUNTIME DESTINATION bin)
-	install(TARGETS arib25-static arib25-shared ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
-	install(FILES src/arib_std_b25.h src/b_cas_card.h src/multi2.h src/ts_section_parser.h src/portable.h ${CMAKE_CURRENT_BINARY_DIR}/arib25_api.h DESTINATION include/arib25)
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${ARIB25_LIB_NAME}.pc DESTINATION lib/pkgconfig)
+	install(TARGETS b25 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+	install(TARGETS arib25-static arib25-shared ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+	install(FILES src/arib_std_b25.h src/b_cas_card.h src/multi2.h src/ts_section_parser.h src/portable.h ${CMAKE_CURRENT_BINARY_DIR}/arib25_api.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/arib25)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${ARIB25_LIB_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -DLDCONFIG_EXECUTABLE=${LDCONFIG_EXECUTABLE} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/PostInstall.cmake)")
 	
 	add_custom_target(uninstall ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Uninstall.cmake)


### PR DESCRIPTION
## 変更点
Issue #14 で報告されているように、Gentoo では 64bit の共有ライブラリは `/usr/local/lib64` に配置すべきですが、実際には CMakeLists.txt にてインストール先ディレクトリがハードコーディングされていたため、`/usr/local/lib` にインストールされてしまいます。

古い Gentoo 64bit 版では `/usr/local/lib` が `/usr/local/lib64` へのシンボリックリンクであったため、この問題が顕在化してきませんでしたが最新の Gentoo ではこのシンボリックリンクが廃止されているようです。
この PR では、この問題を解決します。

副作用として、CMake の最小バージョンが 2.8 から 2.8.5 まで引き上げられました。また結果として、CMake による C++ のコンパイラの機能チェックが厳格になったため Cygwin でコンパイルがコケるようになりました。
この問題についても、この PR にて修正済みです（単なる依存パッケージのタイポでした）。

## フォローアップ
実際には、libarib25 では C++ 言語は使用していませんが、
ビルトインされている GenerateExportHeader マクロが C++ にのみ対応しているため `__attribute__((__deprecated__))` などの属性指定が使用可能かどうかのチェックを C++ コンパイラで行われるようです。

CMake の公式では、GenerateExportHeader マクロの C 言語対応パッチが投稿されているようですが、テスト待のキューに入っていてまだマージされていないと思います。

マージされれば、C++ コンパイラへの不要な依存を排除できますが、それだけの理由で CMake の最小バージョンを上げるのは得策ではないと思うので GenerateExportHeader の C コンパイラ対応済み版を libarib25 にバンドルして CMake のバージョンによってビルトインのマクロを使用するかバンドルしたマクロを使用するかを分けるようにした方がいいかもしれません。
