### PR TITLE
進行状況のパーセント表示を修正

### DIFF
--- a/src/td.c
+++ b/src/td.c
@@ -279,7 +279,7 @@ static void test_arib_std_b25(const TCHAR *src, const TCHAR *dst, OPTION *opt)
 		
 		offset += sbuf.size;
 		if(opt->verbose != 0){
-			m = (int)(10000*offset/total);
+			m = (int)((uint64_t)10000*offset/total);
 			mbps = 0.0;
 #if defined(_WIN32)
 			tick = GetTickCount();


### PR DESCRIPTION
サイズが2GBを超えるファイルの変換時、進行状況のパーセント表示が正しくない件について、
td.cの282行目の
m = (int)(10000offset/total);
を、
m = (int)((uint64_t)10000offset/total);
と修正すれば直るようです。
Linuxで確認しました。