### PR TITLE
Fix broken CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,24 @@ environment:
 
   matrix:
     # Latest version of VisualStudio
+    - JOB_NAME: "Visual Studio 16 2019 (Win32)"
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      CMAKE_GENERATOR_PLATFORM: Win32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - JOB_NAME: "Visual Studio 16 2019 (Win64)"
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      CMAKE_GENERATOR_PLATFORM: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - JOB_NAME: "Visual Studio 16 2019 (ARM)"
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      CMAKE_GENERATOR_PLATFORM: ARM
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - JOB_NAME: "Visual Studio 16 2019 (ARM64)"
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      CMAKE_GENERATOR_PLATFORM: ARM64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+
+    # Windows Server 2012R2 or Windows 8 or above
     - JOB_NAME: "Visual Studio 15 2017 (Win32)"
       CMAKE_GENERATOR: "Visual Studio 15 2017"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,43 +12,58 @@ environment:
 
   matrix:
     # Latest version of VisualStudio
-    - GENERATOR: "Visual Studio 15 2017"
+    - JOB_NAME: "Visual Studio 15 2017 (Win32)"
+      CMAKE_GENERATOR: "Visual Studio 15 2017"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - GENERATOR: "Visual Studio 15 2017 Win64"
+    - JOB_NAME: "Visual Studio 15 2017 (Win64)"
+      CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     # Windows Server 2008R2 or Windows 7 or above
-    - GENERATOR: "Visual Studio 14 2015"
-    - GENERATOR: "Visual Studio 14 2015 Win64"
-    - GENERATOR: "Visual Studio 12 2013"
-    - GENERATOR: "Visual Studio 12 2013 Win64"
-    - GENERATOR: "Visual Studio 11 2012"
-    - GENERATOR: "Visual Studio 11 2012 Win64"
+    - JOB_NAME: "Visual Studio 14 2015 (Win32)"
+      CMAKE_GENERATOR: "Visual Studio 14 2015"
+    - JOB_NAME: "Visual Studio 14 2015 (Win64)"
+      CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+    - JOB_NAME: "Visual Studio 12 2013 (Win32)"
+      CMAKE_GENERATOR: "Visual Studio 12 2013"
+    - JOB_NAME: "Visual Studio 12 2013 (Win64)"
+      CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
+    - JOB_NAME: "Visual Studio 11 2012 (Win32)"
+      CMAKE_GENERATOR: "Visual Studio 11 2012"
+    - JOB_NAME: "Visual Studio 11 2012 (Win64)"
+      CMAKE_GENERATOR: "Visual Studio 11 2012 Win64"
 
     # WindowsXP or above (C99 is not yet supported)
-    - GENERATOR: "Visual Studio 10 2010"
-    - GENERATOR: "Visual Studio 10 2010 Win64"
-    - GENERATOR: "Visual Studio 9 2008"
+    - JOB_NAME: "Visual Studio 10 2010 (Win32)"
+      CMAKE_GENERATOR: "Visual Studio 10 2010"
+    - JOB_NAME: "Visual Studio 10 2010 (Win64)"
+      CMAKE_GENERATOR: "Visual Studio 10 2010 Win64"
+    - JOB_NAME: "Visual Studio 9 2008 (Win32)"
+      CMAKE_GENERATOR: "Visual Studio 9 2008"
 
     # MSYS2
-    - GENERATOR: "MSYS Makefiles"
+    - JOB_NAME: "MSYS2 MinGW32 (i686)"
+      CMAKE_GENERATOR: "MSYS Makefiles"
       BUILDENV: MSYS2
       MSYS2_ARCH: i686
       MSYSTEM: MINGW32
 
-    - GENERATOR: "MSYS Makefiles"
+    - JOB_NAME: "MSYS2 MinGW64 (x86_64)"
+      CMAKE_GENERATOR: "MSYS Makefiles"
       BUILDENV: MSYS2
       MSYS2_ARCH: x86_64
       MSYSTEM: MINGW64
 
     # Cygwin
-    - GENERATOR: "Unix Makefiles"
+    - JOB_NAME: "Cygwin32 (x86)"
+      CMAKE_GENERATOR: "Unix Makefiles"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       BUILDENV: CYGWIN
       CYGWIN_DIR: cygwin
       CYGWIN_ARCH: x86
 
-    - GENERATOR: "Unix Makefiles"
+    - JOB_NAME: "Cygwin64 (x86_64)"
+      CMAKE_GENERATOR: "Unix Makefiles"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       BUILDENV: CYGWIN
       CYGWIN_DIR: cygwin64
@@ -77,26 +92,22 @@ before_build:
 
   - if "%BUILDENV%" == "MSBUILD" (
       cd build &&
-      cmake -G "%GENERATOR%" ..
+      cmake --version &&
+      cmake ..
     )
 
-  - if "%BUILDENV%" == "MSYS2" (
-      mklink /D "%MSYS2_ROOT%/home/%USERNAME%/work" "%APPVEYOR_BUILD_FOLDER%" &&
-      "%MSYS2_ROOT%/usr/bin/bash" --login -c 'cd work/build; cmake -G "%GENERATOR%" ..'
-    )
+  - if "%BUILDENV%" == "MSYS2"
+      "%MSYS2_ROOT%/usr/bin/bash" --login -c 'cd "${APPVEYOR_BUILD_FOLDER}/build"; cmake ..'
 
-  - if "%BUILDENV%" == "CYGWIN" (
-      mklink /D "%CYGWIN_ROOT%/home/%USERNAME%/work" "%APPVEYOR_BUILD_FOLDER%" &&
-      "%CYGWIN_ROOT%/bin/bash" --login -c 'cd ~/work/build; cmake -G "%GENERATOR%" ..'
-    )
-
+  - if "%BUILDENV%" == "CYGWIN"
+      "%CYGWIN_ROOT%/bin/bash" --login -c 'cd "${APPVEYOR_BUILD_FOLDER}/build"; cmake ..'
 
 build_script:
   - if "%BUILDENV%" == "MSBUILD"
       msbuild "%SOLUTION%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
   - if "%BUILDENV%" == "MSYS2"
-      "%MSYS2_ROOT%/usr/bin/bash" --login -c 'cd ~/work/build; make'
+      "%MSYS2_ROOT%/usr/bin/bash" --login -c 'cd "${APPVEYOR_BUILD_FOLDER}/build"; make'
 
   - if "%BUILDENV%" == "CYGWIN"
-      "%CYGWIN_ROOT%/bin/bash" --login -c 'cd ~/work/build; make'
+      "%CYGWIN_ROOT%/bin/bash" --login -c 'cd "${APPVEYOR_BUILD_FOLDER}/build"; make'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -75,14 +75,14 @@ environment:
     # Cygwin
     - JOB_NAME: "Cygwin32 (x86)"
       CMAKE_GENERATOR: "Unix Makefiles"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       BUILDENV: CYGWIN
       CYGWIN_DIR: cygwin
       CYGWIN_ARCH: x86
 
     - JOB_NAME: "Cygwin64 (x86_64)"
       CMAKE_GENERATOR: "Unix Makefiles"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       BUILDENV: CYGWIN
       CYGWIN_DIR: cygwin64
       CYGWIN_ARCH: x86_64
@@ -115,10 +115,10 @@ before_build:
     )
 
   - if "%BUILDENV%" == "MSYS2"
-      "%MSYS2_ROOT%/usr/bin/bash" --login -c 'cd "${APPVEYOR_BUILD_FOLDER}/build"; cmake ..'
+      "%MSYS2_ROOT%/usr/bin/bash" --login -c 'cd "${APPVEYOR_BUILD_FOLDER}/build"; cmake --version; cmake ..'
 
   - if "%BUILDENV%" == "CYGWIN"
-      "%CYGWIN_ROOT%/bin/bash" --login -c 'cd "${APPVEYOR_BUILD_FOLDER}/build"; cmake ..'
+      "%CYGWIN_ROOT%/bin/bash" --login -c 'cd "${APPVEYOR_BUILD_FOLDER}/build"; cmake --version; cmake ..'
 
 build_script:
   - if "%BUILDENV%" == "MSBUILD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,21 +80,20 @@ before_script:
         "${TARGET_REPO}" "${ROOTFS}" "${TARGET_SITE}";
       sudo mount --bind /home "${ROOTFS}/home";
       export SHELL="sudo chroot ${ROOTFS} /bin/bash";
-      export WORKDIR=$(pwd);
     else
       export SHELL="/bin/bash";
-      export WORKDIR=$(pwd);
     fi
 
 script:
   - >
-    ${SHELL} <<EOF
-      install -d "${WORKDIR}/build"
-      cd "${WORKDIR}/build"
+    ${SHELL} -e <<EOF
+      install -d "${TRAVIS_BUILD_DIR}/build"
+      cd "${TRAVIS_BUILD_DIR}/build"
       cmake ..
       make VERBOSE=1
       ./b25 2>&1 | grep --color=auto "ARIB STD-B25"
       if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
         ./libarib25.so 2>&1 | grep --color=auto "ARIB STD-B25"
       fi
+      exit
     EOF


### PR DESCRIPTION
Appveyor や Travis CI のビルドがコケるようになってしまっていたので修正しました。
また、VisualStudio 2019 のビルドに対応しています。

### 変更点
* Cygwin32 / Cygwin64 のビルドが正常に完了しない問題修正  
  原因は不明ですが、AppVeyor の VisualStudio 2017 のイメージに問題があるようです。  
 VisualStudio 2019 のイメージを使用してビルドするように修正しました。
* Travis CI ビルドできるもののエラーとして報告される問題修正  
* VisualStudio 2019 でのビルドに対応  
  ARM アーキテクチャが増えてきているので VisualStudio 2019 のみ Win32 / Win64 に加えて ARM / ARM64 をターゲットにしたビルドに対応しました
* AppVeyor でのビルドジョブにわかりやすい名前をつけた

### フォローアップ
* Github Actions が機能も充実してきて高速なため移行あるいは並存させても良いかもしれない