### PR TITLE
use __ARM_NEON along with __ARM_NEON__ to detect NEON availability

### DIFF
--- a/src/multi2_cipher.h
+++ b/src/multi2_cipher.h
@@ -194,7 +194,7 @@ inline void decrypt_cbc_ofb(uint8_t *buf, size_t n, const iv_type &iv, const wor
 		decrypt_block<x86::xmm>(buf, n, state, key, round);
 	}
 
-#elif defined(__ARM_NEON__)
+#elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 	if (MULTI2_LIKELY(n == 184)) {
 		decrypt_block<arm::neon2<7> >(buf, n, state, key, round);
 		decrypt_block<arm::neon2<8> >(buf, n, state, key, round);

--- a/src/multi2_neon.h
+++ b/src/multi2_neon.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__ARM_NEON__)
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 #if !defined(__BYTE_ORDER__) || !defined(__ORDER_LITTLE_ENDIAN__) || (__BYTE_ORDER__) != (__ORDER_LITTLE_ENDIAN__)
 	#error "Currently, USE_NEON is only for little-endian."
@@ -110,4 +110,4 @@ inline arm::neon rot1_add_dec<arm::neon>(const arm::neon &v) {
 
 }
 
-#endif /* __ARM_NEON__ */
+#endif /* __ARM_NEON__ || __ARM_NEON */

--- a/src/multi2_neon2.h
+++ b/src/multi2_neon2.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__ARM_NEON__)
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 #include <utility>
 #include <arm_neon.h>
@@ -198,4 +198,4 @@ inline arm::neon2<S> rot1_add_dec(const arm::neon2<S> &v) {
 
 }
 
-#endif /* __ARM_NEON__ */
+#endif /* __ARM_NEON__ || __ARM_NEON */


### PR DESCRIPTION
Aarch64 (Raspberry Pi 4B + Arch Linux ARM 5.11.4) でadvanced SIMD (Neon)が使用できるよう、判定するマクロシンボルの追加をしました。

https://github.com/openwall/john/issues/1998 によると、 `__ARM_NEON__` ではなく `__ARM_NEON` で判別するのが適切なようです。
置き換えてしまっても良さそうですが、後方互換も考え念のためどちらかがあれば有効になるようにしています。

なお、 Arch Linux ARMでしか確認していませんが、Aarch64では `-march` `-mtune` いずれを指定していない状態でも `__ARM_NEON` は定義された状態になります

#### RasPi 4B armv7l

- mitty@raspi-301:~$ uname -a
```
Linux raspi-301 5.10.60-1-ARCH #1 SMP Sat Aug 21 14:56:39 UTC 2021 armv7l GNU/Linux
```
- mitty@raspi-301:~$ gcc -v
```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/armv7l-unknown-linux-gnueabihf/10.2.0/lto-wrapper
Target: armv7l-unknown-linux-gnueabihf
Configured with: /build/gcc/src/gcc/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://github.com/archlinuxarm/PKGBUILDs/issues --enable-languages=c,c++,fortran,go,lto,objc,obj-c++,d --with-isl --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-install-libiberty --enable-linker-build-id --enable-lto --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-libunwind-exceptions --disable-multilib --disable-werror --host=armv7l-unknown-linux-gnueabihf --build=armv7l-unknown-linux-gnueabihf --with-arch=armv7-a --with-float=hard --with-fpu=vfpv3-d16 gdc_include_dir=/usr/include/dlang/gdc
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 10.2.0 (GCC)
```
- mitty@raspi-301:~$ gcc -E -dM -x c - < /dev/null | grep -i NEON
    - n/a
- mitty@raspi-301:~$ gcc -mfpu=neon -E -dM -x c - < /dev/null | grep -i NEON
```
#define __ARM_NEON 1
#define __ARM_NEON_FP 4
#define __ARM_NEON__ 1
```

#### RasPi 4B Aarch64

- mitty@alarm:~$ uname -a
```
Linux alarm 5.11.4-1-ARCH #1 SMP Sun Mar 7 23:46:10 UTC 2021 aarch64 GNU/Linux
```
- mitty@alarm:~$ gcc -v
```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/lto-wrapper
Target: aarch64-unknown-linux-gnu
Configured with: /build/gcc/src/gcc/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://github.com/archlinuxarm/PKGBUILDs/issues --enable-languages=c,c++,fortran,go,lto,objc,obj-c++,d --with-isl --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-install-libiberty --enable-linker-build-id --enable-lto --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-libunwind-exceptions --disable-multilib --disable-werror --host=aarch64-unknown-linux-gnu --build=aarch64-unknown-linux-gnu --with-arch=armv8-a --enable-fix-cortex-a53-835769 --enable-fix-cortex-a53-843419 gdc_include_dir=/usr/include/dlang/gdc
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 10.2.0 (GCC)
```
- mitty@alarm:~$ gcc -E -dM -x c - < /dev/null | grep -i NEON
```
#define __ARM_NEON 1
```
- mitty@alarm:~$ gcc -march=armv8-a+crc+simd -mtune=cortex-a72 -E -dM -x c - < /dev/null | grep -i NEON
```
#define __ARM_NEON 1
```

---

- RasPi 4B におけるCFLAGSはこちらを参照 https://wiki.gentoo.org/wiki/Raspberry_Pi4_64_Bit_Install#CFLAGS