### PR TITLE
コマンドライン引数の処理を getopt に置き換え

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,8 @@ endif()
 link_directories(${PCSC_LIBRARY_DIRS})
 
 add_library(arib25-objlib OBJECT src/arib_std_b25.c src/b_cas_card.c src/multi2.cc src/ts_section_parser.c src/version.c)
+set_target_properties(arib25-objlib PROPERTIES C_STANDARD 90)
+set_target_properties(arib25-objlib PROPERTIES CXX_STANDARD 98)
 set_target_properties(arib25-objlib PROPERTIES COMPILE_DEFINITIONS ARIB25_DLL)
 
 add_library(arib25-static STATIC $<TARGET_OBJECTS:arib25-objlib>)
@@ -120,7 +122,7 @@ set_target_properties(arib25-shared PROPERTIES VERSION ${ARIB25_VERSION_NUMBER})
 target_link_libraries(arib25-shared PRIVATE ${PCSC_LIBRARIES})
 generate_export_header(arib25-shared BASE_NAME arib25_api EXPORT_FILE_NAME arib25_api.h)
 
-add_executable(b25 src/td.c ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+add_executable(b25 src/td.c src/getopt.c ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 set_target_properties(b25 PROPERTIES OUTPUT_NAME ${ARIB25_CMD_NAME})
 target_link_libraries(b25 PRIVATE ${PCSC_LIBRARIES})
 target_link_libraries(b25 PRIVATE arib25-shared)

--- a/NOTICE
+++ b/NOTICE
@@ -6,3 +6,9 @@ This product include software from MARUMO Manufacturing libarib25 project.
   * Copyright (c)2007-2012 MOGI, Kazuhiro <kazhiro@marumo.ne.jp>; All rights reserved.
      MARUMO Manufacturing (https://www.marumo.ne.jp/) 
      Special Thanks: 2ch NoNames, eternalharvest, eru.
+
+This product include code derived from musl project.
+  * Copyright 2005-2014 Rich Felker, et al.
+     Files:
+       - src/getopt.h
+       - src/getopt.c

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -1,0 +1,212 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include "getopt.h"
+
+char *optarg;
+int optind=1, opterr=1, optopt, __optpos, optreset=0;
+
+#define optpos __optpos
+
+static void __getopt_msg(const char *a, const char *b, const char *c, size_t l)
+{
+	FILE *f = stderr;
+	flockfile(f);
+	fputs(a, f)>=0
+	&& fwrite(b, strlen(b), 1, f)
+	&& fwrite(c, 1, l, f)==l
+	&& putc('\n', f);
+	funlockfile(f);
+}
+
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+	int i, c, d;
+	int k, l;
+	char *optchar;
+
+	if (!optind || optreset) {
+		optreset = 0;
+		__optpos = 0;
+		optind = 1;
+	}
+
+	if (optind >= argc || !argv[optind])
+		return -1;
+
+	if (argv[optind][0] != '-') {
+		if (optstring[0] == '-') {
+			optarg = argv[optind++];
+			return 1;
+		}
+		return -1;
+	}
+
+	if (!argv[optind][1])
+		return -1;
+
+	if (argv[optind][1] == '-' && !argv[optind][2])
+		return optind++, -1;
+
+	if (!optpos) optpos++;
+	c = argv[optind][optpos], k = 1;
+	optchar = argv[optind]+optpos;
+	optopt = c;
+	optpos += k;
+
+	if (!argv[optind][optpos]) {
+		optind++;
+		optpos = 0;
+	}
+
+	if (optstring[0] == '-' || optstring[0] == '+')
+		optstring++;
+
+	i = 0;
+	d = 0;
+	do {
+		d = optstring[i], l = 1;
+		if (l>0) i+=l; else i++;
+	} while (l && d != c);
+
+	if (d != c) {
+		if (optstring[0] != ':' && opterr)
+			__getopt_msg(argv[0], ": unrecognized option: ", optchar, k);
+		return '?';
+	}
+	if (optstring[i] == ':') {
+		if (optstring[i+1] == ':') optarg = 0;
+		else if (optind >= argc) {
+			if (optstring[0] == ':') return ':';
+			if (opterr) __getopt_msg(argv[0],
+				": option requires an argument: ",
+				optchar, k);
+			return '?';
+		}
+		if (optstring[i+1] != ':' || optpos) {
+			optarg = argv[optind++] + optpos;
+			optpos = 0;
+		}
+	}
+	return c;
+}
+
+static void permute(char *const *argv, int dest, int src)
+{
+	char **av = (char **)argv;
+	char *tmp = av[src];
+	int i;
+	for (i=src; i>dest; i--)
+		av[i] = av[i-1];
+	av[dest] = tmp;
+}
+
+static int __getopt_long_core(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx, int longonly)
+{
+	optarg = 0;
+	if (longopts && argv[optind][0] == '-' &&
+		((longonly && argv[optind][1] && argv[optind][1] != '-') ||
+		 (argv[optind][1] == '-' && argv[optind][2])))
+	{
+		int colon = optstring[optstring[0]=='+'||optstring[0]=='-']==':';
+		int i, cnt, match;
+		char *opt;
+		for (cnt=i=0; longopts[i].name; i++) {
+			const char *name = longopts[i].name;
+			opt = argv[optind]+1;
+			if (*opt == '-') opt++;
+			for (; *name && *name == *opt; name++, opt++);
+			if (*opt && *opt != '=') continue;
+			match = i;
+			if (!*name) {
+				cnt = 1;
+				break;
+			}
+			cnt++;
+		}
+		if (cnt==1) {
+			i = match;
+			optind++;
+			optopt = longopts[i].val;
+			if (*opt == '=') {
+				if (!longopts[i].has_arg) {
+					if (colon || !opterr)
+						return '?';
+					__getopt_msg(argv[0],
+						": option does not take an argument: ",
+						longopts[i].name,
+						strlen(longopts[i].name));
+					return '?';
+				}
+				optarg = opt+1;
+			} else if (longopts[i].has_arg == required_argument) {
+				if (!(optarg = argv[optind])) {
+					if (colon) return ':';
+					if (!opterr) return '?';
+					__getopt_msg(argv[0],
+						": option requires an argument: ",
+						longopts[i].name,
+						strlen(longopts[i].name));
+					return '?';
+				}
+				optind++;
+			}
+			if (idx) *idx = i;
+			if (longopts[i].flag) {
+				*longopts[i].flag = longopts[i].val;
+				return 0;
+			}
+			return longopts[i].val;
+		}
+		if (argv[optind][1] == '-') {
+			if (!colon && opterr)
+				__getopt_msg(argv[0], cnt ?
+					": option is ambiguous: " :
+					": unrecognized option: ",
+					argv[optind]+2,
+					strlen(argv[optind]+2));
+			optind++;
+			return '?';
+		}
+	}
+	return getopt(argc, argv, optstring);
+}
+
+static int __getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx, int longonly)
+{
+	int ret, skipped, resumed;
+	if (!optind || optreset) {
+		optreset = 0;
+		__optpos = 0;
+		optind = 1;
+	}
+	if (optind >= argc || !argv[optind]) return -1;
+	skipped = optind;
+	if (optstring[0] != '+' && optstring[0] != '-') {
+		int i;
+		for (i=optind; ; i++) {
+			if (i >= argc || !argv[i]) return -1;
+			if (argv[i][0] == '-' && argv[i][1]) break;
+		}
+		optind = i;
+	}
+	resumed = optind;
+	ret = __getopt_long_core(argc, argv, optstring, longopts, idx, longonly);
+	if (resumed > skipped) {
+		int i, cnt = optind-resumed;
+		for (i=0; i<cnt; i++)
+			permute(argv, skipped, optind-1);
+		optind = skipped + cnt;
+	}
+	return ret;
+}
+
+int getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
+{
+	return __getopt_long(argc, argv, optstring, longopts, idx, 0);
+}
+
+int getopt_long_only(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
+{
+	return __getopt_long(argc, argv, optstring, longopts, idx, 1);
+}

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -1,0 +1,53 @@
+/*
+  Copyright 2005-2014 Rich Felker, et al.
+  
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+  
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _GETOPT_H
+#define _GETOPT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int getopt(int, char * const [], const char *);
+extern char *optarg;
+extern int optind, opterr, optopt, optreset;
+
+struct option {
+	const char *name;
+	int has_arg;
+	int *flag;
+	int val;
+};
+
+int getopt_long(int, char *const *, const char *, const struct option *, int *);
+int getopt_long_only(int, char *const *, const char *, const struct option *, int *);
+
+#define no_argument        0
+#define required_argument  1
+#define optional_argument  2
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -28,23 +28,31 @@
 extern "C" {
 #endif
 
-int getopt(int, char * const [], const char *);
-extern char *optarg;
+#if defined(_WIN32)
+#include <tchar.h>
+#else
+#define TCHAR char
+#endif
+
+int getopt(int, TCHAR * const [], const TCHAR *);
+extern TCHAR *optarg;
 extern int optind, opterr, optopt, optreset;
 
 struct option {
-	const char *name;
+	const TCHAR *name;
 	int has_arg;
 	int *flag;
 	int val;
 };
 
-int getopt_long(int, char *const *, const char *, const struct option *, int *);
-int getopt_long_only(int, char *const *, const char *, const struct option *, int *);
+int getopt_long(int, TCHAR *const *, const TCHAR *, const struct option *, int *);
+int getopt_long_only(int, TCHAR *const *, const TCHAR *, const struct option *, int *);
 
 #define no_argument        0
 #define required_argument  1
 #define optional_argument  2
+
+#undef TCHAR
 
 #ifdef __cplusplus
 }

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -1,5 +1,8 @@
 /*
   Copyright 2005-2014 Rich Felker, et al.
+
+  This code is derived from software contributed to musl project
+  by Rich Felker.
   
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the

--- a/src/td.c
+++ b/src/td.c
@@ -146,7 +146,9 @@ static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 				exit(EXIT_SUCCESS);
 				break;
 
+
 			default:
+				optopt && _ftprintf(stderr, _T("%s: unrecognized option: %c\n"), argv[0], optopt);
 				exit(EXIT_FAILURE);
 				break;
 		}

--- a/src/td.c
+++ b/src/td.c
@@ -93,6 +93,8 @@ static void show_usage()
 	_ftprintf(stderr, _T("  -v verbose\n"));
 	_ftprintf(stderr, _T("     0: silent\n"));
 	_ftprintf(stderr, _T("     1: show processing status (default)\n"));
+	_ftprintf(stderr, _T("  -V, --version\n"));
+	_ftprintf(stderr, _T("     show version\n"));
 	_ftprintf(stderr, _T("  -h, --help\n"));
 	_ftprintf(stderr, _T("     show this help message\n"));
 	_ftprintf(stderr, _T("\n"));
@@ -102,6 +104,7 @@ static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 {
 	static struct option longopts[] = {
 		{"help", no_argument, NULL, 'h'},
+		{"version", no_argument, NULL, 'V'},
 		{NULL, 0, NULL, 0}
 	};
 	
@@ -111,7 +114,7 @@ static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 	dst->power_ctrl = 1;
 	dst->verbose = 1;
 
-	while (getopt_long(argc, argv, "m:p:r:s:v:h", longopts, NULL) != -1) {
+	while (getopt_long(argc, argv, "m:p:r:s:v:hV", longopts, NULL) != -1) {
 		switch (optopt) {
 			case 'm':
 				dst->emm = _ttoi(optarg);
@@ -135,6 +138,11 @@ static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 
 			case 'h':
 				show_usage();
+				exit(EXIT_SUCCESS);
+				break;
+
+			case 'V':
+				_ftprintf(stderr, _T("%s\n"), _T(BUILD_GIT_REVISION));
 				exit(EXIT_SUCCESS);
 				break;
 

--- a/src/td.c
+++ b/src/td.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <config.h>
+#include "getopt.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -97,7 +98,9 @@ static void show_usage()
 
 static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 {
-	int i;
+	static struct option longopts[] = {
+		{NULL, 0, NULL, 0}
+	};
 	
 	dst->round = 4;
 	dst->strip = 0;
@@ -105,58 +108,35 @@ static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 	dst->power_ctrl = 1;
 	dst->verbose = 1;
 
-	for(i=1;i<argc;i++){
-		if(argv[i][0] != '-'){
-			break;
-		}
-		switch(argv[i][1]){
-		case 'm':
-			if(argv[i][2]){
-				dst->emm = _ttoi(argv[i]+2);
-			}else{
-				dst->emm = _ttoi(argv[i+1]);
-				i += 1;
-			}
-			break;
-		case 'p':
-			if(argv[i][2]){
-				dst->power_ctrl = _ttoi(argv[i]+2);
-			}else{
-				dst->power_ctrl = _ttoi(argv[i+1]);
-				i += 1;
-			}
-			break;
-		case 'r':
-			if(argv[i][2]){
-				dst->round = _ttoi(argv[i]+2);
-			}else{
-				dst->round = _ttoi(argv[i+1]);
-				i += 1;
-			}
-			break;
-		case 's':
-			if(argv[i][2]){
-				dst->strip = _ttoi(argv[i]+2);
-			}else{
-				dst->strip = _ttoi(argv[i+1]);
-				i += 1;
-			}
-			break;
-		case 'v':
-			if(argv[i][2]){
-				dst->verbose = _ttoi(argv[i]+2);
-			}else{
-				dst->verbose = _ttoi(argv[i+1]);
-				i += 1;
-			}
-			break;
-		default:
-			_ftprintf(stderr, _T("error - unknown option '-%c'\n"), argv[i][1]);
-			return argc;
+	while (getopt_long(argc, argv, "m:p:r:s:v:", longopts, NULL) != -1) {
+		switch (optopt) {
+			case 'm':
+				dst->emm = _ttoi(optarg);
+				break;
+
+			case 'p':
+				dst->power_ctrl = _ttoi(optarg);
+				break;
+
+			case 'r':
+				dst->round = _ttoi(optarg);
+				break;
+
+			case 's':
+				dst->strip = _ttoi(optarg);
+				break;
+
+			case 'v':
+				dst->verbose = _ttoi(optarg);
+				break;
+
+			default:
+				exit(EXIT_FAILURE);
+				break;
 		}
 	}
 
-	return i;
+	return optind;
 }
 
 static void test_arib_std_b25(const TCHAR *src, const TCHAR *dst, OPTION *opt)

--- a/src/td.c
+++ b/src/td.c
@@ -103,8 +103,8 @@ static void show_usage()
 static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 {
 	static struct option longopts[] = {
-		{"help", no_argument, NULL, 'h'},
-		{"version", no_argument, NULL, 'V'},
+		{_T("help"), no_argument, NULL, 'h'},
+		{_T("version"), no_argument, NULL, 'V'},
 		{NULL, 0, NULL, 0}
 	};
 	
@@ -114,7 +114,7 @@ static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 	dst->power_ctrl = 1;
 	dst->verbose = 1;
 
-	while (getopt_long(argc, argv, "m:p:r:s:v:hV", longopts, NULL) != -1) {
+	while (getopt_long(argc, argv, _T("m:p:r:s:v:hV"), longopts, NULL) != -1) {
 		switch (optopt) {
 			case 'm':
 				dst->emm = _ttoi(optarg);

--- a/src/td.c
+++ b/src/td.c
@@ -93,12 +93,15 @@ static void show_usage()
 	_ftprintf(stderr, _T("  -v verbose\n"));
 	_ftprintf(stderr, _T("     0: silent\n"));
 	_ftprintf(stderr, _T("     1: show processing status (default)\n"));
+	_ftprintf(stderr, _T("  -h, --help\n"));
+	_ftprintf(stderr, _T("     show this help message\n"));
 	_ftprintf(stderr, _T("\n"));
 }
 
 static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 {
 	static struct option longopts[] = {
+		{"help", no_argument, NULL, 'h'},
 		{NULL, 0, NULL, 0}
 	};
 	
@@ -108,7 +111,7 @@ static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 	dst->power_ctrl = 1;
 	dst->verbose = 1;
 
-	while (getopt_long(argc, argv, "m:p:r:s:v:", longopts, NULL) != -1) {
+	while (getopt_long(argc, argv, "m:p:r:s:v:h", longopts, NULL) != -1) {
 		switch (optopt) {
 			case 'm':
 				dst->emm = _ttoi(optarg);
@@ -128,6 +131,11 @@ static int parse_arg(OPTION *dst, int argc, TCHAR **argv)
 
 			case 'v':
 				dst->verbose = _ttoi(optarg);
+				break;
+
+			case 'h':
+				show_usage();
+				exit(EXIT_SUCCESS);
 				break;
 
 			default:


### PR DESCRIPTION
b25 コマンドのコマンドライン引数の処理の実装が簡易的なものであるため、間違った引数を指定すると segmentation fault でプロセスが以上終了したりと不親切な設計であるため、また POSIX スタイルの --version 等の長い形式のオプションにも対応することを容易にするため getopt で置き換えました。

この変更により下記の Issue を解決します。
Closes #31, Closes #32

getopt の実装は、標準 C ライブラリの軽量実装の一つ musl プロジェクトより借用し、オリジナルのライセンスは MIT ライセンスのため Apache License 2.0 との互換性は問題ありません。また、上記借用の旨ヘッダーと NOTICE ファイルに記載しております。また、getopt 自体は Windows の UNICODE 実装に非対応のため、UNICODE 対応のために一部改変してあります。