### PR TITLE
VisualStudio 2017 移行の統合された CMake に対応

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,6 @@ charset = utf-8
 indent_style = tab
 indent_size = 2
 
-[*.yml]
+[*.yml,*.json]
 indent_style = space
 indent_size = 2

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,48 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\build\\${name}",
+      "installRoot": "${projectDir}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\build\\${name}",
+      "installRoot": "${projectDir}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ]
+    },
+    {
+      "name": "x86-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\build\\${name}",
+      "installRoot": "${projectDir}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x86" ]
+    },
+    {
+      "name": "x86-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\build\\${name}",
+      "installRoot": "${projectDir}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x86" ]
+    }
+  ]
+}


### PR DESCRIPTION
以前より VisualStudio は CMake にて対応していましたが、CMake を使って VisualStudio のソリューションファイルを生成しなければならず Windows でのビルドが少々不便でした。VisualStudio 2017 以降では、CMake が組み込まれておりソリューションファイルを生成しなくても VisualStudio でビルドすることが可能となっています。

この PR は、VisualStudio が CMake を用いて libarib25 をビルドするための設定が含まれています。これにより、VisualStudio でのビルドに事前に CMake 等のセットアップや設定ファイルの生成する処理が不要になります。

VisualStudio 2019 以降は、Git からのプロジェクトのクローンにも対応しているためビルドがより容易になるはずです。